### PR TITLE
set headers on azure context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,7 @@ export default function azureFunctionHandler(app, binaryTypes) {
       httpMethod: req.method,
       headers: req.headers || {},
       queryStringParameters: req.query || {},
-      // Azure automatically converts body to a JSON object if the content-type is application/json,
-      // since aws-serverless-express expects a raw object we convert it back to string before proxying it
-      body:
-        req.headers['content-type'] === 'application/json'
-          ? req.rawBody
-          : req.body,
+      body: req.rawBody
       isBase64Encoded: false
     };
 


### PR DESCRIPTION
This PR set headers on azure context.
Others minor fix:
1. Use `req.rawBody` instead `JSON.stringify(req.body)` see [this](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-functions/functions-reference-node.md#http-triggers-and-bindings) for more informations

1. Allow users to define `binaryTypes`.